### PR TITLE
Add Claude AI tools taxonomy documentation and validation command

### DIFF
--- a/.claude/commands/validate-claude-tools.md
+++ b/.claude/commands/validate-claude-tools.md
@@ -1,0 +1,371 @@
+---
+description: Validate Claude tools in .claude/ against Anthropic best practices. Optionally pass a specific path to validate.
+---
+
+Validate Claude AI tools against Anthropic's official documentation and best practices.
+
+**Target:** $ARGUMENTS (if empty, validate all of `.claude/`)
+
+## Setup
+
+1. If `$ARGUMENTS` is provided, validate only that path
+2. If `$ARGUMENTS` is empty, validate the entire `.claude/` directory
+3. Create output file: `CLAUDE_MEMO_AI_TOOLS_REVIEW.md` in the project root
+
+## Frontmatter Schemas
+
+**IMPORTANT:** Each tool type has different valid frontmatter fields. Use these authoritative schemas.
+
+### Subagents (`.claude/agents/*.md`)
+```yaml
+---
+name: lowercase-with-hyphens        # Required (max 64 chars)
+description: What this agent does   # Required (max 1024 chars)
+tools: Read, Write, Bash            # Optional - tools the agent can use
+model: sonnet | opus | haiku | inherit  # Optional - defaults to inherit
+permissionMode: default | acceptEdits | bypassPermissions | plan | ignore  # Optional
+skills: skill1, skill2              # Optional - skills to auto-load
+---
+```
+
+### Skills (`.claude/skills/*/SKILL.md`)
+```yaml
+---
+name: skill-name                    # Required (max 64 chars)
+description: What and when          # Required (max 1024 chars)
+allowed-tools: ["Read", "Write"]    # Optional - constrain tool access
+---
+```
+
+### Commands (`.claude/commands/*.md`)
+```yaml
+---
+description: What this command does # Required
+argument-hint: <arg1> [arg2]        # Optional
+allowed-tools: Read, Write          # Optional
+model: sonnet | opus | haiku        # Optional - override model for this command
+---
+```
+
+**Key distinction:** Agents use `tools:` field. Skills and commands use `allowed-tools:` field. Do not confuse these.
+
+---
+
+## Validation Framework
+
+For each tool type, check the applicable rules below.
+
+### Skills (`.claude/skills/*/SKILL.md`)
+
+**Structure validation:**
+- [ ] SKILL.md exists in skill directory
+- [ ] YAML frontmatter has opening and closing `---` delimiters
+- [ ] Required field: `name` (lowercase, numbers, hyphens only, max 64 chars)
+- [ ] Required field: `description` (non-empty, max 1024 chars, no XML tags)
+- [ ] No reserved words in name: "anthropic", "claude"
+
+**Naming convention:**
+- [ ] Directory name matches `name` field in frontmatter
+- [ ] Name uses gerund form (verb + -ing): e.g., `writing-documentation` not `docs-writer`
+
+**Best practices:**
+- [ ] Description includes both what the skill does AND when to use it
+- [ ] Description includes trigger phrases/keywords users would say
+- [ ] SKILL.md body is under 500 lines
+- [ ] Progressive disclosure: explicit "Read X when Y" instructions for bundled files
+- [ ] References to other files use forward slashes (not backslashes)
+- [ ] If scripts exist, SKILL.md explains when to run vs read them
+- [ ] Feedback loops documented if validation scripts exist
+- [ ] No time-sensitive information that will become outdated
+
+**File validation:**
+- [ ] All internal markdown links resolve to existing files
+- [ ] All referenced scripts exist and have valid syntax
+- [ ] No placeholder text: `[TODO]`, `[PLACEHOLDER]`, `TBD`, `xxx`
+- [ ] Code blocks have language hints
+
+### Agents (`.claude/agents/*.md`)
+
+**Structure validation:**
+- [ ] YAML frontmatter has opening and closing `---` delimiters
+- [ ] Required field: `name` (lowercase, numbers, hyphens only, max 64 chars)
+- [ ] Required field: `description` (max 1024 chars, no XML tags)
+- [ ] No examples or XML tags in description field (must be in body)
+
+**Field validation (agents use different fields than skills/commands):**
+- [ ] If present, `tools:` field lists valid tool names (NOT `allowed-tools:`)
+- [ ] If `model:` is present, value must be one of: `sonnet`, `opus`, `haiku`, `inherit`
+- [ ] `inherit` is valid and means "use the same model as main conversation"
+- [ ] If `model:` is absent, agent inherits by default (this is valid)
+
+**Best practices:**
+- [ ] Name uses gerund form matching the activity
+- [ ] Description explains when the agent should be invoked
+- [ ] Body includes concrete examples of appropriate use
+- [ ] If agent references skills, those skills exist
+- [ ] Clear scope definition (what it handles vs what it doesn't)
+
+### Slash Commands (`.claude/commands/*.md`)
+
+**Structure validation:**
+- [ ] YAML frontmatter has `description` field
+- [ ] Description is concise (1-2 sentences)
+
+**Best practices:**
+- [ ] Uses `$ARGUMENTS` if command accepts input
+- [ ] Handles empty `$ARGUMENTS` case (asks user or uses default)
+- [ ] Clear step-by-step instructions
+- [ ] No ambiguous decision points left to Claude
+
+### CLAUDE.md / Memory Files
+
+**Structure validation:**
+- [ ] Valid markdown syntax
+- [ ] No broken internal links
+
+**Best practices:**
+- [ ] Clear section organization
+- [ ] Actionable instructions (not vague guidance)
+- [ ] No contradictory rules
+
+### Reference Files (`references/*.md`)
+
+**Validation:**
+- [ ] Valid markdown syntax
+- [ ] Referenced by parent SKILL.md or agent
+- [ ] No orphaned files (exist but never referenced)
+
+### Scripts (`scripts/*.py`, `scripts/*.sh`, etc.)
+
+**Validation:**
+- [ ] Valid syntax for language (parse check)
+- [ ] Referenced in SKILL.md or agent
+- [ ] Has usage documentation (docstring or header comment)
+- [ ] Executable permissions if shell script
+
+---
+
+## Cross-Reference Validation
+
+Tools reference each other. Broken references are real bugs this validator must catch.
+
+### Agent → Skill references
+- [ ] If agent has `skills:` field, each skill name exists in `.claude/skills/`
+- [ ] Skill names in frontmatter match actual directory names
+
+### Command → Agent references
+- [ ] If command body mentions "use the X agent" or "invoke X agent", agent X exists in `.claude/agents/`
+- [ ] If command references `/other-command`, that command exists in `.claude/commands/`
+
+### Skill → File references
+- [ ] If SKILL.md references `scripts/foo.py`, that file exists in the skill directory
+- [ ] If SKILL.md references `references/bar.md`, that file exists in the skill directory
+- [ ] If SKILL.md references `templates/baz.md`, that file exists in the skill directory
+
+### Orphan detection
+- [ ] No files in skill `scripts/` subdirectory that aren't referenced by SKILL.md
+- [ ] No files in skill `references/` subdirectory that aren't referenced by SKILL.md
+- [ ] No files in skill `templates/` subdirectory that aren't referenced by SKILL.md
+
+### Related Tools table validation
+- [ ] If tool has "Related Tools" section, verify each referenced tool exists
+- [ ] Check that command names match actual filenames (e.g., `/fix-issue-status` → `fix-issue-status.md`)
+- [ ] Check that agent names match actual filenames (e.g., `issues-housekeeper` → `issues-housekeeper.md`)
+
+---
+
+## Common False Positives to Avoid
+
+**Do NOT flag these as errors:**
+
+| Situation | Why it's valid |
+|-----------|----------------|
+| Agent using `tools:` instead of `allowed-tools:` | Agents correctly use `tools:` field |
+| Agent with `model: inherit` | Valid value meaning "use same model as main conversation" |
+| Skill without `model:` field | Skills don't use model fields |
+| Command without `name:` field | Commands don't require name (description is the key field) |
+| Agent without `allowed-tools:` field | Agents use `tools:`, not `allowed-tools:` |
+| Skill using `allowed-tools:` instead of `tools:` | Skills correctly use `allowed-tools:` field |
+
+**Before flagging a field as incorrect:**
+1. Verify which tool type the file is (agent vs skill vs command) based on file path
+2. Consult the Frontmatter Schemas section above for the correct fields
+3. Only flag if the field is genuinely wrong for that specific tool type
+
+---
+
+## Analysis Process
+
+0. **Verify schemas**: Before validating any field names, consult the Frontmatter Schemas section above. Do NOT rely on assumptions or patterns from other tools in the codebase. Each tool type has its own valid fields.
+1. **Inventory**: List all tools found in `.claude/`
+2. **Classify**: Determine each tool's type based on file path (`.claude/agents/` = agent, `.claude/skills/` = skill, `.claude/commands/` = command)
+3. **Validate**: Run all applicable checks for each tool, using the correct schema for that tool type
+4. **Categorize findings**:
+   - **ERRORS**: Broken functionality (missing required fields, invalid syntax, broken links)
+   - **WARNINGS**: Functional but non-conforming to best practices
+   - **SUGGESTIONS**: Optimization opportunities
+5. **Prioritize**: For each tool, identify top 3 highest-ROI improvements
+
+## Output Format
+
+### Console Summary
+
+Provide a brief summary to the user:
+
+````markdown
+## Validation Results
+
+Scanned: X skills, Y agents, Z commands, W other files
+
+### Errors (must fix)
+
+| Tool | Issue | Suggested Fix |
+|------|-------|---------------|
+| [tool-name] | [description of error] | [specific fix instruction] |
+
+Example:
+| my-agent | Uses `allowed-tools:` instead of `tools:` | Change line 4: `allowed-tools:` → `tools:` |
+| my-skill | Missing `description` field | Add `description: Brief summary of what this does and when to use it` |
+
+### Warnings (should fix)
+
+| Tool | Issue | Suggested Fix |
+|------|-------|---------------|
+| [tool-name] | [description of issue] | [specific fix instruction] |
+
+### Cross-Reference Issues (if any)
+
+| Source | References | Problem |
+|--------|------------|---------|
+| [tool-name] | [referenced item] | [missing/broken/orphaned] |
+
+### Top Improvements
+1. [highest impact change]
+2. [second highest]
+3. [third highest]
+
+Full analysis written to: CLAUDE_MEMO_AI_TOOLS_REVIEW.md
+````
+
+### Technical Memo (CLAUDE_MEMO_AI_TOOLS_REVIEW.md)
+
+Create a detailed markdown file with this structure:
+
+````markdown
+# Claude AI Tools Review
+
+**Generated:** [timestamp]
+**Scope:** [path validated]
+
+## Executive Summary
+
+[2-3 sentence overview of findings]
+
+## Inventory
+
+| Type | Count | With Errors | With Warnings |
+|------|-------|-------------|---------------|
+| Skills | X | Y | Z |
+| Agents | X | Y | Z |
+| Commands | X | Y | Z |
+| Other | X | Y | Z |
+
+## Detailed Findings
+
+### Skills
+
+#### [skill-name]
+**Status:** [PASS | WARNINGS | ERRORS]
+
+**Errors:**
+- [list any errors]
+
+**Warnings:**
+- [list any warnings]
+
+**Top 3 Improvements:**
+1. [improvement + why it matters]
+2. [improvement + why it matters]
+3. [improvement + why it matters]
+
+[Repeat for each skill]
+
+### Agents
+
+[Same format as skills]
+
+### Commands
+
+[Same format as skills]
+
+## Global Recommendations
+
+[Cross-cutting improvements that affect multiple tools]
+
+## Checklist for Fixes
+
+- [ ] [specific action item]
+- [ ] [specific action item]
+- [ ] [specific action item]
+````
+
+## Common Fix Templates
+
+Include these copy-paste ready fixes in the memo when applicable:
+
+### Missing description (for skills/agents)
+```yaml
+description: [What it does]. Use when [trigger conditions/keywords].
+```
+
+### Convert allowed-tools to tools (for agents)
+```diff
+- allowed-tools: Read, Write
++ tools: Read, Write
+```
+
+### Convert tools to allowed-tools (for skills/commands)
+```diff
+- tools: Read, Write
++ allowed-tools: Read, Write
+```
+
+### Add missing Source section (for issues)
+```markdown
+## Source
+This issue is part of the work defined in: `../specs/SPEC_{name}.md`
+```
+
+### Fix model field (invalid value)
+```diff
+- model: gpt-4
++ model: sonnet
+```
+Valid values: `sonnet`, `opus`, `haiku`, `inherit`
+
+### Add argument handling (for commands)
+```markdown
+**Input:** `$ARGUMENTS` — [description of expected input]
+
+If `$ARGUMENTS` is empty, [ask user for input OR use default behavior].
+```
+
+---
+
+## Future Enhancement: Auto-Fix Mode
+
+> **Not yet implemented.** When available, `/validate-claude-tools --fix` will automatically correct:
+> - Field name mismatches (`allowed-tools` ↔ `tools`)
+> - Missing required fields (with templates)
+> - Format inconsistencies (array vs comma-separated)
+> - Broken cross-references (suggest closest match)
+
+---
+
+## Validation
+
+After creating the memo, confirm:
+1. `CLAUDE_MEMO_AI_TOOLS_REVIEW.md` exists in project root
+2. All errors are clearly actionable with specific fix instructions
+3. Summary was provided to user with tabular format
+4. Cross-reference issues are identified and reported

--- a/.wrangler/memos/2026-01-16-claude-ai-tools-taxonomy-gaps.md
+++ b/.wrangler/memos/2026-01-16-claude-ai-tools-taxonomy-gaps.md
@@ -1,0 +1,216 @@
+# Claude AI Tools Taxonomy: Wrangler Gap Analysis
+
+**Date:** 2026-01-16
+**Context:** Conversation exploring sitrep feature revealed fundamental confusion about Claude AI tool types
+**Status:** Analysis complete, action items identified
+
+---
+
+## Executive Summary
+
+During exploration of a proposed `/wrangler:sitrep` feature, it became clear that wrangler conflates three distinct Claude AI tool types: **skills**, **agents**, and **slash commands**. This confusion is reflected in both the codebase structure and in AI assistant behavior (incorrectly claiming `/wrangler:issues` was available when it wasn't).
+
+The `validate-claude-tools` skill documents authoritative Anthropic schemas that wrangler should align with.
+
+---
+
+## The Three Claude AI Tool Types
+
+Per Anthropic best practices documented in `.claude/commands/validate-claude-tools.md`:
+
+### 1. Skills (`.claude/skills/*/SKILL.md`)
+
+**Purpose:** Reusable knowledge/process patterns that Claude loads into context
+
+**Frontmatter schema:**
+```yaml
+---
+name: skill-name                    # Required (max 64 chars, gerund form)
+description: What and when          # Required (max 1024 chars)
+allowed-tools: ["Read", "Write"]    # Optional - constrain tool access
+---
+```
+
+**Key characteristics:**
+- Live in directories (not flat files)
+- Name uses gerund form: `writing-documentation` not `docs-writer`
+- Description must include WHAT it does AND WHEN to use it
+- Body contains the actual skill instructions
+- Uses `allowed-tools:` (NOT `tools:`)
+
+### 2. Agents (`.claude/agents/*.md`)
+
+**Purpose:** Autonomous subprocesses that can be spawned via Task tool
+
+**Frontmatter schema:**
+```yaml
+---
+name: lowercase-with-hyphens        # Required (max 64 chars)
+description: What this agent does   # Required (max 1024 chars)
+tools: Read, Write, Bash            # Optional - tools agent can use
+model: sonnet | opus | haiku | inherit  # Optional
+permissionMode: default | acceptEdits | bypassPermissions | plan | ignore
+skills: skill1, skill2              # Optional - skills to auto-load
+---
+```
+
+**Key characteristics:**
+- Flat markdown files (not directories)
+- Uses `tools:` field (NOT `allowed-tools:`)
+- Can specify model override
+- Can auto-load skills
+- Invoked via Task tool with `subagent_type` parameter
+
+### 3. Slash Commands (`.claude/commands/*.md`)
+
+**Purpose:** User-invocable shortcuts that expand into prompts
+
+**Frontmatter schema:**
+```yaml
+---
+description: What this command does # Required
+argument-hint: <arg1> [arg2]        # Optional
+allowed-tools: Read, Write          # Optional
+model: sonnet | opus | haiku        # Optional
+---
+```
+
+**Key characteristics:**
+- Flat markdown files
+- No `name:` field required (filename is the name)
+- Uses `$ARGUMENTS` placeholder for user input
+- Uses `allowed-tools:` (NOT `tools:`)
+- Invoked with `/command-name` syntax
+
+---
+
+## Critical Distinction
+
+| Aspect | Skills | Agents | Commands |
+|--------|--------|--------|----------|
+| Location | `.claude/skills/*/SKILL.md` | `.claude/agents/*.md` | `.claude/commands/*.md` |
+| Structure | Directory with SKILL.md | Flat file | Flat file |
+| Tool field | `allowed-tools:` | `tools:` | `allowed-tools:` |
+| Invocation | Skill tool or auto-loaded | Task tool | `/command-name` |
+| Purpose | Knowledge/process | Autonomous work | User shortcuts |
+
+---
+
+## Wrangler's Current State
+
+### Directory Structure Mismatch
+
+Wrangler uses:
+```
+wrangler/
+├── skills/           # Skills (correct location concept)
+│   └── {name}/
+│       └── SKILL.md
+├── commands/         # Commands (but at repo root, not .claude/)
+│   └── {name}.md
+```
+
+Anthropic standard expects:
+```
+.claude/
+├── skills/
+│   └── {name}/
+│       └── SKILL.md
+├── agents/
+│   └── {name}.md
+├── commands/
+│   └── {name}.md
+```
+
+### Specific Issues Found
+
+1. **`commands/issues.md` exists but isn't functional**
+   - File is present at `commands/issues.md`
+   - Not registered in the Skill tool's available list
+   - AI incorrectly claimed it was available
+
+2. **No `.claude/agents/` directory**
+   - Wrangler has agent-like patterns (subagent dispatch in housekeeping)
+   - But no formal agent definitions per Anthropic schema
+
+3. **Skills at non-standard location**
+   - Wrangler skills are at `skills/` (repo root)
+   - Standard is `.claude/skills/`
+   - May affect discoverability
+
+4. **Unclear registration mechanism**
+   - How do commands get from `commands/*.md` to being invocable?
+   - Why is `housekeeping` available but `issues` is not?
+   - Registration process not documented
+
+---
+
+## Recommendations
+
+### Immediate (Documentation)
+
+1. **Document the tool type distinction in CLAUDE.md**
+   - Add section explaining skills vs agents vs commands
+   - Reference the validate-claude-tools skill
+
+2. **Audit commands/ directory**
+   - Which commands are actually registered?
+   - Why are some available and others not?
+   - Document the registration mechanism
+
+### Short-term (Alignment)
+
+3. **Consider `.claude/` standard structure**
+   - Evaluate moving to `.claude/skills/`, `.claude/commands/`
+   - Or document why wrangler diverges from standard
+
+4. **Create agents for subagent patterns**
+   - Housekeeping dispatches 4 subagents
+   - These could be formal `.claude/agents/*.md` definitions
+
+### For Sitrep Feature
+
+5. **Decide: skill, agent, or command?**
+   - If user-invoked shortcut → command (`/wrangler:sitrep`)
+   - If autonomous subprocess → agent
+   - If process knowledge → skill
+   - Likely: command that orchestrates agents
+
+---
+
+## Original Conversation Context
+
+The user was exploring a `/wrangler:sitrep` feature that would:
+1. Check latest merged PRs and commits on GitHub
+2. Check recently changed wrangler files
+3. Summarize latest decisions
+4. Announce new questions
+5. Show upcoming roadmap work
+6. Re-evaluate priority ranking
+
+Gap analysis found:
+- No GitHub API integration
+- No session delta tracking ("what changed since last time")
+- No automatic decision aggregation
+- No priority re-evaluation logic
+
+The `/wrangler:issues` command was referenced as existing functionality, but turned out to be non-functional—highlighting the broader issue of unclear tool registration and conflated terminology.
+
+---
+
+## Action Items
+
+- [ ] Audit which commands are actually registered and why
+- [ ] Document skill vs agent vs command distinction in CLAUDE.md
+- [ ] Decide on sitrep implementation type (command vs skill vs agent)
+- [ ] Consider alignment with `.claude/` standard structure
+- [ ] Run `/validate-claude-tools` on wrangler's own `.claude/` directory
+
+---
+
+## References
+
+- `.claude/commands/validate-claude-tools.md` - Authoritative schema documentation
+- `skills/using-wrangler/SKILL.md` - Current skill usage guidance
+- `commands/issues.md` - Example of non-functional command
+- `skills/housekeeping/SKILL.md` - Example of subagent dispatch pattern


### PR DESCRIPTION
Wrangler confuses different official AI tools in the Anthropic toolkit for Claude Code (e.g. doesn't seem to know the difference between skills and slash commands in particular). 

This 2 things that i think will be useful:
- a slash command `/validate-claude-tools`) , NOT part of the wrangler plugin itself but included in the repo specifically to help us work on wrangler itself. the slash command has explicit instructions on how to decide whether to a feature should be implemented as a slash command, skilll, agent, etc. based on direct references to official Anthropic documentation for each of the different claude AI tool types. 
- a technical memo (`wrangler/memos/2026-01-16-claude-ai-tools-taxonomy-gaps.md`) summarizing research findings into wrangler's use of terms / terminology and how well wrangler adheres to official anthropic best practices for using different tool types. 

1. `.claude/commands/validate-claude-tools.md` - A slash command that validates tools in .claude/ against Anthropic best practices, including authoritative frontmatter schemas for:
   - Skills (.claude/skills/*/SKILL.md) - use `allowed-tools:`
   - Agents (.claude/agents/*.md) - use `tools:`
   - Commands (.claude/commands/*.md) - use `allowed-tools:`

2. `.wrangler/memos/2026-01-16-claude-ai-tools-taxonomy-gaps.md` - Gap analysis documenting the distinction between skills, agents, and commands, and identifying areas where wrangler could better align with Anthropic standards.

Key insight: wrangler conflates these three tool types, which led to confusion about which commands are actually available (e.g., commands/issues.md exists but isn't registered/invocable).