### PR TITLE
Add --help flag with docopt-style usage docs to /wrangler:sitrep

### DIFF
--- a/commands/sitrep.md
+++ b/commands/sitrep.md
@@ -1,11 +1,79 @@
 ---
 description: Generate a situational report showing what's new since your last sitrep
-argument-hint: "[--full]"
+argument-hint: "[--full | --help]"
 ---
 
-## Invoke Skill
+## Check for Help Flag
 
-Use the Skill tool to load the sitrep skill:
+If `$ARGUMENTS` contains `--help` or `help`:
+
+**Display help and exit** - do NOT invoke the skill. Output the help text below directly:
+
+````
+/wrangler:sitrep - Situational Awareness Report
+
+USAGE:
+    /wrangler:sitrep [OPTIONS]
+
+DESCRIPTION:
+    Generate a "what's new" report showing activity since your last sitrep.
+    Surfaces new memos, recent commits, decisions, open questions, and
+    roadmap status to keep you informed before evaluating priorities.
+
+    On first run, shows the last 7 days of activity. Subsequent runs show
+    only new activity since your last sitrep (incremental updates).
+
+OPTIONS:
+    --full     Ignore cursor, show full 7-day report (like first run)
+    --help     Show this help message and exit
+
+FILES READ:
+    .wrangler/cache/{user}-sitrep.json    Your sitrep cursor state
+    .wrangler/memos/*.md                  Memo files for surfacing
+    .wrangler/ROADMAP_NEXT_STEPS.md       Roadmap completion status
+    .wrangler/issues/*.md                 Issue status (via MCP)
+
+FILES WRITTEN:
+    .wrangler/cache/{user}-sitrep.json    Updated cursor after each run
+
+STATE FILE FORMAT:
+    {
+      "cursor": { "commit": "abc123" },   # Last commit you saw
+      "stats": { "runs": 5, ... }         # Cumulative stats
+    }
+
+WORKFLOW:
+    1. Detect user from git config (email prefix)
+    2. Load cursor from state file (or default to 7 days)
+    3. Gather data in parallel:
+       - Git commits since cursor
+       - New memos with decisions/questions
+       - Issue and roadmap status
+    4. Generate report with:
+       - NEW MEMOS (read first!)
+       - Recent activity by author
+       - Decisions made
+       - Open questions
+       - Roadmap status & high-priority issues
+    5. Update cursor to latest commit
+
+EXAMPLES:
+    /wrangler:sitrep              # Incremental: what's new since last run
+    /wrangler:sitrep --full       # Full overview: last 7 days
+    /wrangler:sitrep --help       # Show this help
+
+SEE ALSO:
+    /wrangler:issues              # View issue/spec status
+    /wrangler:help                # Full wrangler documentation
+````
+
+**After displaying help, stop.** Do not invoke the skill.
+
+---
+
+## Invoke Skill (Normal Execution)
+
+If no help flag, use the Skill tool to load the sitrep skill:
 
 ```
 Skill: sitrep
@@ -13,6 +81,3 @@ Args: $ARGUMENTS
 ```
 
 The skill handles state management, data gathering, and report generation.
-
-**Arguments:**
-- `--full` - Ignore cursor, show full report (useful for first day on project)

--- a/skills/sitrep/SKILL.md
+++ b/skills/sitrep/SKILL.md
@@ -20,6 +20,74 @@ You are the sitrep workflow coordinator. Your job is to surface what's new since
 
 ---
 
+## Help Flag Handling
+
+**FIRST:** Check if arguments contain `--help` or `help`.
+
+If help flag is present, output this help text and **stop** (do not proceed to workflow):
+
+````
+/wrangler:sitrep - Situational Awareness Report
+
+USAGE:
+    /wrangler:sitrep [OPTIONS]
+
+DESCRIPTION:
+    Generate a "what's new" report showing activity since your last sitrep.
+    Surfaces new memos, recent commits, decisions, open questions, and
+    roadmap status to keep you informed before evaluating priorities.
+
+    On first run, shows the last 7 days of activity. Subsequent runs show
+    only new activity since your last sitrep (incremental updates).
+
+OPTIONS:
+    --full     Ignore cursor, show full 7-day report (like first run)
+    --help     Show this help message and exit
+
+FILES READ:
+    .wrangler/cache/{user}-sitrep.json    Your sitrep cursor state
+    .wrangler/memos/*.md                  Memo files for surfacing
+    .wrangler/ROADMAP_NEXT_STEPS.md       Roadmap completion status
+    .wrangler/issues/*.md                 Issue status (via MCP)
+
+FILES WRITTEN:
+    .wrangler/cache/{user}-sitrep.json    Updated cursor after each run
+
+STATE FILE FORMAT:
+    {
+      "cursor": { "commit": "abc123" },   # Last commit you saw
+      "stats": { "runs": 5, ... }         # Cumulative stats
+    }
+
+WORKFLOW:
+    1. Detect user from git config (email prefix)
+    2. Load cursor from state file (or default to 7 days)
+    3. Gather data in parallel:
+       - Git commits since cursor
+       - New memos with decisions/questions
+       - Issue and roadmap status
+    4. Generate report with:
+       - NEW MEMOS (read first!)
+       - Recent activity by author
+       - Decisions made
+       - Open questions
+       - Roadmap status & high-priority issues
+    5. Update cursor to latest commit
+
+EXAMPLES:
+    /wrangler:sitrep              # Incremental: what's new since last run
+    /wrangler:sitrep --full       # Full overview: last 7 days
+    /wrangler:sitrep --help       # Show this help
+
+SEE ALSO:
+    /wrangler:issues              # View issue/spec status
+    /wrangler:help                # Full wrangler documentation
+````
+
+**After displaying help, STOP.** Do not proceed to the multi-phase workflow.
+
+---
+
 ## Multi-Phase Workflow
 
 ```


### PR DESCRIPTION
## Summary

- Add `--help` flag support to `/wrangler:sitrep` command
- Display docopt-style help showing usage, options, files read/written, workflow steps, and examples
- Improves developer experience by making command behavior discoverable

## What the help output looks like

```
/wrangler:sitrep - Situational Awareness Report

USAGE:
    /wrangler:sitrep [OPTIONS]

DESCRIPTION:
    Generate a "what's new" report showing activity since your last sitrep.
    Surfaces new memos, recent commits, decisions, open questions, and
    roadmap status to keep you informed before evaluating priorities.

OPTIONS:
    --full     Ignore cursor, show full 7-day report (like first run)
    --help     Show this help message and exit

FILES READ:
    .wrangler/cache/{user}-sitrep.json    Your sitrep cursor state
    .wrangler/memos/*.md                  Memo files for surfacing
    ...

EXAMPLES:
    /wrangler:sitrep              # Incremental: what's new since last run
    /wrangler:sitrep --full       # Full overview: last 7 days
    /wrangler:sitrep --help       # Show this help
```

## Test plan

- [ ] Run `/wrangler:sitrep --help` and verify help text displays
- [ ] Run `/wrangler:sitrep` and verify normal execution still works
- [ ] Run `/wrangler:sitrep --full` and verify full report works

🤖 Generated with [Claude Code](https://claude.com/claude-code)